### PR TITLE
Use AP resolver to get WebSocket URL

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -96,6 +96,9 @@ function Spotify () {
     song:  'http://open.spotify.com/track/6JEK0CvvjDjjMUBFoXShNZ'
   };
 
+  // the client version to "emulate"
+  this.clientVersion = 41800000; // client version: 0.4.18.0, deployed 2013-05-17 13:15 UTC
+
   // base URLs for Image files like album artwork, artist prfiles, etc.
   // these values taken from "spotify.web.client.js"
   this.sourceUrl = 'https://d3rt1990lpmkn.cloudfront.net';
@@ -238,19 +241,41 @@ Spotify.prototype._onauth = function (err, res) {
     this.emit('error', new Error(msg));
   } else {
     this.settings = res.body.config;
-    this._openWebsocket();
+    this._resolveAP();
   }
 };
 
+/** 
+ * Resolves the WebSocket AP to connect to
+ * Should be called after the _onauth() function
+ *
+ * @api private
+ */
+Spotify.prototype._resolveAP = function() {
+  var resolver = this.settings.aps.resolver;
+  debug('ap resolver %j', resolver);
+  var req = this.agent.get('http://' + resolver.hostname)
+    .set({ 'User-Agent': this.userAgent })
+    .query({client : '24:0:0:' + this.clientVersion});
+  if (resolver.site)
+    req.query({site: resolver.site});
+  req.end(this._openWebsocket.bind(this));
+}
+
 /**
  * Opens the WebSocket connection to the Spotify Web server.
- * Should be called after the _onauth() function.
+ * Should be called upon AP resolver's response.
  *
  * @api private.
  */
 
-Spotify.prototype._openWebsocket = function () {
-  var url = this.settings.aps.ws[0];
+Spotify.prototype._openWebsocket = function (err, res) {
+  if (err) return this.emit('error', err);
+
+  debug('ap resolver %d status code, %j content-type', res.statusCode, res.headers['content-type']);
+  var ap_list = res.body.ap_list;
+  var url = 'wss://' + ap_list[0] + '/';
+
   debug('WS %j', url);
   this.ws = new WebSocket(url);
   this.ws.on('open', this._onopen);


### PR DESCRIPTION
Websocket url no longer within auth response, now inside a response from a secondary server. Hardcodes client version parameter from current client version, and adds a `_resolveAP` private method which should be called between the auth and the openWebsocket.

Tested and seems to communicate ok, however I still cannot play tracks due to other errors.
