### PR TITLE
proto: change contentType to bytes format

### DIFF
--- a/proto/mercury.desc
+++ b/proto/mercury.desc
@@ -16,7 +16,7 @@
 cache_policy (2/.spotify.mercury.proto.MercuryReply.CachePolicy
 ttl (
 etag (
-content_type (	
+content_type (
 body ("@
 CachePolicy
 CACHE_NO

--- a/proto/mercury.proto
+++ b/proto/mercury.proto
@@ -23,6 +23,6 @@ message MercuryReply {
   optional CachePolicy cache_policy = 3;
   optional sint32 ttl = 4;
   optional bytes etag = 5;
-  optional string content_type = 6;
+  optional bytes content_type = 6;
   optional bytes body = 7;
 }


### PR DESCRIPTION
This works around the non-UTF8 character error that is emitted when parsing
some mercury responses by changing the type of the contentType field to bytes.

Derrived from Hexxeh/spotify-websocket-api@e6b2d8772d

Fixes TooTallNate/node-spotify-web#11
