### PR TITLE
Support MercuryMultiGetRequest

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -485,6 +485,7 @@ Spotify.prototype.metadata = function (uris, fn) {
   }
   // array of "request" Objects that will be protobuf'd
   var requests = [];
+  var mtype = "";
   uris.forEach(function (uri) {
     var type = util.uriType(uri);
     if ('local' == type) {
@@ -492,6 +493,7 @@ Spotify.prototype.metadata = function (uris, fn) {
       return;
     }
     var id = util.uri2id(uri);
+    mtype = type;
     requests.push({
       body: 'GET',
       uri: 'hm://metadata/' + type + '/' + id
@@ -504,7 +506,17 @@ Spotify.prototype.metadata = function (uris, fn) {
     data = MercuryRequest.serialize(requests[0]).toString('base64');
     args.push(data);
   } else {
-    throw new Error('implement!');
+    data = MercuryMultiGetRequest.serialize({
+      request: requests
+    }).toString('base64');
+    var header = MercuryRequest.serialize({
+      body: "GET",
+      contentType: "vnd.spotify/mercury-mget-request",
+      uri: "hm://metadata/" + mtype + "s"
+    }).toString('base64');
+
+    args.push(header);
+    args.push(data)
   }
 
   this.sendCommand('sp/hm_b64', args, function (err, res) {
@@ -515,8 +527,13 @@ Spotify.prototype.metadata = function (uris, fn) {
     var header = self._parse(MercuryReply, new Buffer(data[0], 'base64'));
     debug('response header: %j', header);
     if ('vnd.spotify/mercury-mget-reply' == header.statusMessage) {
-      // multi-get request
-      throw new Error('implement!');
+      ret = [];
+      var response = self._parse(MercuryMultiGetReply, new Buffer(data[1], 'base64'));
+      for (var i = 0; i < response.reply.length; i++) {
+        var type = response.reply[i].contentType.toString();
+        ret.push(parseItem(type, response.reply[i].body));
+      }
+      debug('parsed response: %d items', ret.length);
     } else {
       // single entry response
       ret = parseItem(header.statusMessage, data[1]);


### PR DESCRIPTION
Fetches multiple metadata items at once. This can help avoid the "toomanyrequests" error.
