### PR TITLE
Emit error on track.play() stream if server does not respond with 200 status code

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -94,7 +94,11 @@ Track.prototype.play = function () {
 
   function response (res) {
     debug('HTTP/%s %s', res.httpVersion, res.statusCode);
-    res.pipe(stream);
+    if (res.statusCode == 200) {
+      res.pipe(stream);
+    } else {
+      stream.emit('error', new Error('HTTP Status Code ' + res.statusCode));
+    }
   }
 
   // return stream immediately so it can be .pipe()'d


### PR DESCRIPTION
I keep getting invalid URLs returned from track_uri requests. Obviously this patch doesn't fix them, but it should at least cause an error when it occurs to stop node from crashing by trying to parse an access denied message as an mp3 file. Not sure if it's the right way of doing things, I know streams + errors are difficult to get right.
