### PR TITLE
Improve login by including trackingId and removing secretPayload

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -87,17 +87,11 @@ function Spotify () {
 
   this.authServer = 'play.spotify.com';
   this.authUrl = '/xhr/json/auth.php';
-  this.secretUrl = '/redirect/facebook/notification.php';
+  this.landingUrl = '/';
   this.userAgent = 'node-spotify-web (Chrome/13.37 compatible-ish)';
 
-  // the query-string to send along to the "secret url"
-  this.secretPayload = {
-    album: 'http://open.spotify.com/album/2mCuMNdJkoyiXFhsQCLLqw',
-    song:  'http://open.spotify.com/track/6JEK0CvvjDjjMUBFoXShNZ'
-  };
-
   // the client version to "emulate"
-  this.clientVersion = 41800000; // client version: 0.4.18.0, deployed 2013-05-17 13:15 UTC
+  this.clientVersion = 60200000; // client version: 0.6.2.0, deployed 2013-07-08 08:50 UTC
 
   // base URLs for Image files like album artwork, artist prfiles, etc.
   // these values taken from "spotify.web.client.js"
@@ -169,11 +163,20 @@ Spotify.prototype.login = function (un, pw, fn) {
   // save credentials for later...
   this.creds = { username: un, password: pw };
 
-  var url = 'https://' + this.authServer + this.secretUrl;
+  this._makeLandingPageRequest();
+};
+
+/**
+ * Makes a request for the landing page to get the CSRF token.
+ *
+ * @api private
+ */
+
+Spotify.prototype._makeLandingPageRequest = function() {
+  var url = 'https://' + this.authServer + this.landingUrl;
   debug('GET %j', url);
   this.agent.get(url)
     .set({ 'User-Agent': this.userAgent })
-    .query(this.secretPayload)
     .end(this._onsecret.bind(this));
 };
 
@@ -187,32 +190,36 @@ Spotify.prototype.login = function (un, pw, fn) {
 Spotify.prototype._onsecret = function (err, res) {
   if (err) return this.emit('error', err);
 
-  debug('secret %d status code, %j content-type', res.statusCode, res.headers['content-type']);
+  debug('landing page: %d status code, %j content-type', res.statusCode, res.headers['content-type']);
   var $ = cheerio.load(res.text);
 
-  // need to grab the CSRF token from the page.
+  // need to grab the CSRF token and trackingId from the page.
   // currently, it's inside an Object that gets passed to a
   // `new Spotify.Web.Login()` call as the second parameter.
-  var secret;
-  var key = 'csrftoken';
+  var args;
   var scripts = $('script');
   function login (doc, data) {
     debug('Spotify.Web.Login()');
-    secret = data[key];
+    args = data;
     return { init: function () { /* noop */ } };
   }
   for (var i = 0; i < scripts.length; i++) {
     var code = scripts.eq(i).text();
-    if (~code.indexOf(key)) {
+    if (~code.indexOf('Spotify.Web.Login')) {
       vm.runInNewContext(code, { document: null, Spotify: { Web: { Login: login } } });
     }
   }
-  debug('login CSRF token %j', secret);
+  debug('login CSRF token: %j, tracking ID: %j', args.csrftoken, args.trackingId);
 
+  // construct credentials object to send from stored credentials
   var creds = this.creds;
   delete this.creds;
   creds.type = 'sp';
-  creds.secret = secret;
+  creds.secret = args.csrftoken;
+  creds.trackingId = args.trackingId;
+  creds.landingURL = args.landingURL;
+  creds.referrer = args.referrer;
+  creds.cf = null;
 
   // now we have to "auth" in order to get Spotify Web "credentials"
   var url = 'https://' + this.authServer + this.authUrl;


### PR DESCRIPTION
secretPayload is no longer required as Spotify Play is open to all, and this patch uses the home page as the page to get the csrftoken and trackingId instead of the secretUrl and secretPayload.

It also adds the `trackingId` and other extra arguments to match `Spotify.Web.Authenticator#authenticateWithUsernameAndPassword()` from the proper client.
