### PR TITLE
Support Facebook and Anonymous Logins

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -263,7 +263,6 @@ Spotify.prototype._onsecret = function (err, res) {
   // construct credentials object to send from stored credentials
   var creds = this.creds;
   delete this.creds;
-  creds.type = 'sp';
   creds.secret = args.csrftoken;
   creds.trackingId = args.trackingId;
   creds.landingURL = args.landingURL;


### PR DESCRIPTION
Includes / Supersedes #28.

Supports the other two types of login as separate methods, `spotify#facebookLogin` and `spotfiy#anonymousLogin`. The common functionality dealing with callbacks has been moved to a separate private function `spotify#_setLoginCallbacks`.

Fixes #33.
