### PR TITLE
Use HTTP error descriptions for mercury request errors rather than relying on statusMessage which is usually undefined

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -5,6 +5,7 @@
 
 var vm = require('vm');
 var util = require('./util');
+var http = require('http');
 var WebSocket = require('ws');
 var cheerio = require('cheerio');
 var schemas = require('./schemas');
@@ -604,11 +605,15 @@ Spotify.prototype.sendProtobufRequest = function(req, fn) {
 
     // TODO: proper error handling, handle 300 errors
 
-    if (header.statusCode >= 400 && header.statusCode < 500)
-      return fn(new Error('Client Error: ' + header.statusMessage));
+    if (header.statusCode >= 400 && header.statusCode < 500) {
+      var statusMessage = header.statusMessage || http.STATUS_CODES[header.statusCode] || 'Unknown Error';
+      return fn(new Error('Client Error: ' + statusMessage + ' (' + header.statusCode + ')'));
+    }
 
-    if (header.statusCode >= 500 && header.statusCode < 600)
-      return fn(new Error('Server Error: ' + header.statusMessage));
+    if (header.statusCode >= 500 && header.statusCode < 600) {
+      var statusMessage = header.statusMessage || http.STATUS_CODES[header.statusCode] || 'Unknown Error';
+      return fn(new Error('Server Error: ' + statusMessage + ' (' + header.statusCode + ')'));
+    }
 
     if (isMultiGet && 'vnd.spotify/mercury-mget-reply' !== type)
       return fn(new Error('Server Error: Server didn\'t send a multi-GET reply for a multi-GET request!'));


### PR DESCRIPTION
This commit patches the `sendProtobufRequest()` function to emit slightly more useful/readable errors which detail the human-readable status from the `http` module and raw error code. 

As of f49983410b, you should be able to trigger an error such as 401 Unauthorised by requesting another user's rootlist. Before this commit, the error would have been `Error: Client Error: undefined`, instead this patch makes it `Error: Client Error: Unauthorized (401)`.

Fixes #39 
