### PR TITLE
Update user agent and send window size log event on connection

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -14,6 +14,7 @@ var inherits = require('util').inherits;
 var SpotifyError = require('./error');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('spotify-web');
+var package = require('../package.json');
 
 /**
  * Module exports.
@@ -86,10 +87,10 @@ function Spotify () {
   this.authServer = 'play.spotify.com';
   this.authUrl = '/xhr/json/auth.php';
   this.landingUrl = '/';
-  this.userAgent = 'node-spotify-web (Chrome/13.37 compatible-ish)';
+  this.userAgent = 'Mozilla/5.0 (Chrome/13.37 compatible-ish) spotify-web/' + package.version;
 
   // the client version to "emulate"
-  this.clientVersion = 60200000; // client version: 0.6.2.0, deployed 2013-07-08 08:50 UTC
+  this.clientVersion = 62300120; // client version: 0.6.23.120, deployed 2014-01-08 14:28 UTC
 
   // base URLs for Image files like album artwork, artist prfiles, etc.
   // these values taken from "spotify.web.client.js"
@@ -1137,6 +1138,7 @@ Spotify.prototype._onconnect = function (err, res) {
     this.connected = true;
     this.emit('connect');
     this.sendCommand('sp/user_info', this._onuserinfo.bind(this));
+    this.sendCommand('sp/log', [41, 1, 0, 0, 0, 0]); // Spotify.Logging.Logger#logWindowSize
   } else {
     // TODO: handle possible error case
   }


### PR DESCRIPTION
Fixes #60. Similar to #61 but based on master.
- Changes user agent to remove "node-spotify-web" string and replaces it with "spotify-web" and Mozilla/5.0. While we're at it also includes the package version in the user-agent. This will likely be brittle and require changing again if they widen their filter but I'd like to think we can have a nice descriptive user-agent rather than cheating and going to a real browser UA when we aren't actually a real browser.
- Also adds the logging call as mentioned elsewhere previously after the connection has been completed, with a window size of 0x0.
