### PR TITLE
Use client version from auth response instead of hard-coded client version

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -89,9 +89,6 @@ function Spotify () {
   this.landingUrl = '/';
   this.userAgent = 'Mozilla/5.0 (Chrome/13.37 compatible-ish) spotify-web/' + package.version;
 
-  // the client version to "emulate"
-  this.clientVersion = 62300120; // client version: 0.6.23.120, deployed 2014-01-08 14:28 UTC
-
   // base URLs for Image files like album artwork, artist prfiles, etc.
   // these values taken from "spotify.web.client.js"
   this.sourceUrl = 'https://d3rt1990lpmkn.cloudfront.net';
@@ -307,7 +304,7 @@ Spotify.prototype._onauth = function (err, res) {
  */
 
 Spotify.prototype._resolveAP = function () {
-  var query = { client: '24:0:0:' + this.clientVersion };
+  var query = { client: '24:0:0:' + this.settings.version };
   var resolver = this.settings.aps.resolver;
   debug('ap resolver %j', resolver);
   if (resolver.site) query.site = resolver.site;


### PR DESCRIPTION
Removes the hard-coded clientVersion parameter which required manual updating and uses the version returned in the auth response instead when querying for APs.

Props to @richard-ive for pointing this out.
Ref: https://github.com/TooTallNate/node-spotify-web/pull/62#discussion-diff-8749549

I don't think this will matter much in the long-run as the version is only used to select an AP, and the apresolver doesn't seem to care what the number is, but it's nicer code so we should use it.
