### PR TITLE
handle the "disconnect" command gracefully

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -436,6 +436,8 @@ Spotify.prototype._onmessagecommand = function (command, args) {
     }
   } else if ('login_complete' == command) {
     // ignore...
+  } else if ('disconnect' == command) {
+    this.disconnect();
   } else {
     // unhandled message
     console.error(command, args);
@@ -647,10 +649,10 @@ Spotify.prototype.disconnect = function () {
   this.connected = false;
   clearInterval(this._heartbeatId);
   this._heartbeatId = null;
-  if (this.ws) {
-    this.ws.close();
-    this.ws = null;
+  if (this.ws && this.ws.readyState == 1) {
+    this.ws.close();  
   }
+  this.ws = null;
 };
 
 /**


### PR DESCRIPTION
Had my console running for a long time and noticed after a day-ish that command came in. I'm guessing I left my connection open, but at least with this patch it won't throw an error and kill the server.
