### PR TITLE
Added Spotify.Web.App.initialize() no-op Function

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -186,7 +186,7 @@ Spotify.prototype.facebookLogin = function (fbuid, token, fn) {
 
 /**
  * Sets the login and error callbacks to invoke the specified callback function
- * 
+ *
  * @param {Function} fn callback function
  * @api private
  */
@@ -251,7 +251,7 @@ Spotify.prototype._onsecret = function (err, res) {
   for (var i = 0; i < scripts.length; i++) {
     var code = scripts.eq(i).text();
     if (~code.indexOf('Spotify.Web.Login')) {
-      vm.runInNewContext(code, { document: null, Spotify: { Web: { Login: login } } });
+      vm.runInNewContext(code, { document: null, Spotify: { Web: { Login: login, App: { initialize: function() { } } } } });
     }
   }
   debug('login CSRF token: %j, tracking ID: %j', args.csrftoken, args.trackingId);
@@ -521,7 +521,7 @@ Spotify.prototype.sendCommand = function (name, args, fn) {
 };
 
 /**
- * Makes a Protobuf request over the WebSocket connection. 
+ * Makes a Protobuf request over the WebSocket connection.
  * Also known as a MercuryRequest or Hermes Call.
  *
  * @param {Object} req protobuf request object
@@ -532,7 +532,7 @@ Spotify.prototype.sendCommand = function (name, args, fn) {
 Spotify.prototype.sendProtobufRequest = function(req, fn) {
   debug('sendProtobufRequest(%j)', req);
 
-  // extract request object 
+  // extract request object
   var isMultiGet = req.isMultiGet || false;
   var payload = req.payload || [];
   var header = {
@@ -725,7 +725,7 @@ Spotify.prototype.metadata = function (uris, fn) {
     header = requests[0];
     requests = null;
     multiGet = false;
-  } 
+  }
 
   this.sendProtobufRequest({
     header: header,
@@ -823,14 +823,14 @@ Spotify.prototype.rootlist = function (user, from, length, fn) {
 
 /**
  * Retrieve suggested similar tracks to the given track URI
- * 
+ *
  * @param {String} uri track uri
  * @param {Function} fn callback function
  * @api public
  */
 
 Spotify.prototype.similar = function(uri, fn) {
-  debug('similar(%j)', uri);  
+  debug('similar(%j)', uri);
 
   var parts = uri.split(':');
   var type = parts[1];


### PR DESCRIPTION
Recently Spotify Web started calling the initialize() function in the
authentication script which causes an exception to be thrown while
connecting node-spotify-web.  This no-op operation allows authentication
to complete successfully.
