### PR TITLE
Temporary fix to ping_flash2 problem (#87) by using api to generate pong

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -482,7 +482,7 @@ Spotify.prototype.sendPong = function(ping) {
       sp.sendCommand('sp/pong_flash2', [pong]);
     });
   }).on('error', function (err) {
-    return sp.emit('error', err);
+    sp.emit('error', err);
   });
 };
 


### PR DESCRIPTION
At least until a reliable central API can be set up, we can send a request to the spotlite server to generate the pong. Once we have an api up and running, it's just a matter of changing the url of the http request.
