### PR TITLE
Add API-Doc to https://doclets.io

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,3 +1,4 @@
 dir: lib
 articles: 
   - Readme: README.md
+  - Changelog: History.md

--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,3 @@
+dir: lib
+articles: 
+  - Readme: README.md

--- a/lib/album.js
+++ b/lib/album.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var util = require('./util');
@@ -9,12 +10,20 @@ var debug = require('debug')('spotify-web:album');
 
 /**
  * Module exports.
+ * @private
+ */
+
+/**
+ * @class Album
+ *
  */
 
 exports = module.exports = Album;
 
 /**
  * Album URI getter.
+ * @member uri
+ * @memberof Album
  */
 
 Object.defineProperty(Album.prototype, 'uri', {

--- a/lib/album.js
+++ b/lib/album.js
@@ -37,6 +37,7 @@ Object.defineProperty(Album.prototype, 'uri', {
 /**
  * Loads all the metadata for this Album instance. Useful for when you get an only
  * partially filled Album instance from an Album instance for example.
+ * @function
  *
  * @param {Function} fn callback function
  * @api public

--- a/lib/artist.js
+++ b/lib/artist.js
@@ -37,6 +37,7 @@ Object.defineProperty(Artist.prototype, 'uri', {
 /**
  * Loads all the metadata for this Artist instance. Useful for when you get an only
  * partially filled Artist instance from an Album instance for example.
+ * @function
  *
  * @param {Function} fn callback function
  * @api public

--- a/lib/artist.js
+++ b/lib/artist.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var util = require('./util');
@@ -9,12 +10,20 @@ var debug = require('debug')('spotify-web:artist');
 
 /**
  * Module exports.
+ * @private
+ */
+
+/** 
+ * @class Artist
+ *
  */
 
 exports = module.exports = Artist;
 
 /**
  * Artist URI getter.
+ * @member uri
+ * @memberof Artist
  */
 
 Object.defineProperty(Artist.prototype, 'uri', {

--- a/lib/base62.js
+++ b/lib/base62.js
@@ -2,6 +2,7 @@
 /**
  * From Spotify Web client code.
  * See: https://gist.github.com/4463921#file-spotify-web-client-js-L3503-L3546
+ * @private
  */
 
 module.exports = function () {

--- a/lib/error.js
+++ b/lib/error.js
@@ -40,6 +40,7 @@ module.exports = SpotifyError;
 
 /**
  * Spotify error class.
+ * @private
  *
  * Sample `err` objects:
  *

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,12 +1,14 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var inherits = require('util').inherits;
 
 /**
  * Error "domains".
+ * @private
  */
 
 var domains = {
@@ -18,6 +20,7 @@ var domains = {
 
 /**
  * Error "codes".
+ * @private
  */
 
 var codes = {
@@ -30,6 +33,7 @@ var codes = {
 
 /**
  * Module exports.
+ * @private
  */
 
 module.exports = SpotifyError;

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var gid2id = require('./util').gid2id;
@@ -8,12 +9,14 @@ var Image = require('./schemas').build('metadata','Image');
 
 /**
  * Module exports.
+ * @private
  */
 
 exports = module.exports = Image;
 
 /**
  * Image HTTP link getter.
+ * @private
  */
 
 Object.defineProperty(Image.prototype, 'uri', {

--- a/lib/restriction.js
+++ b/lib/restriction.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var util = require('./util');
@@ -8,12 +9,14 @@ var Restriction = require('./schemas').build('metadata','Restriction');
 
 /**
  * Module exports.
+ * @private
  */
 
 exports = module.exports = Restriction;
 
 /**
  * Allowed countries 2-letter code Array getter.
+ * @private
  */
 
 Object.defineProperty(Restriction.prototype, 'allowed', {
@@ -27,6 +30,7 @@ Object.defineProperty(Restriction.prototype, 'allowed', {
 
 /**
  * Forbidden countries 2-letter code Array getter.
+ * @private
  */
 
 Object.defineProperty(Restriction.prototype, 'forbidden', {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var fs = require('fs');
@@ -17,6 +18,7 @@ try {
 
 /**
  * Protocol Buffer schemas.
+ * @private
  */
 
 var library = (protobuf) ? 'protobuf' : 'protobufjs';

--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -694,6 +694,7 @@ Spotify.prototype.disconnect = function () {
 /**
  * Gets the "metadata" object for one or more URIs.
  *
+ * @function
  * @param {Array|String} uris A single URI, or an Array of URIs to get "metadata" for
  * @param {Function} fn callback function
  * @api public

--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -1,5 +1,6 @@
 /**
  * Module dependencies.
+ * @private
  */
 
 var vm = require('vm');
@@ -17,12 +18,14 @@ var pkg = require('../package.json');
 
 /**
  * Module exports.
+ * @private
  */
 
 module.exports = Spotify;
 
 /**
  * Protocol Buffer types.
+ * @private
  */
 
 var MercuryMultiGetRequest = schemas.build('mercury','MercuryMultiGetRequest');
@@ -42,6 +45,7 @@ var StoryList = schemas.build('bartender','StoryList');
 
 /**
  * Re-export all the `util` functions.
+ * @private
  */
 
 Object.keys(util).forEach(function (key) {
@@ -69,6 +73,7 @@ Spotify.login = function (un, pw, fn) {
 
 /**
  * Spotify Web base class.
+ * @class
  *
  * @api public
  */

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var util = require('./util');
@@ -13,12 +14,20 @@ if (!PassThrough) PassThrough = require('readable-stream/passthrough');
 
 /**
  * Module exports.
+ * @private
+ */
+
+/**
+ * @class Track
+ *
  */
 
 exports = module.exports = Track;
 
 /**
  * Track URI getter.
+ * @member uri
+ * @memberof Track
  */
 
 Object.defineProperty(Track.prototype, 'uri', {
@@ -31,6 +40,8 @@ Object.defineProperty(Track.prototype, 'uri', {
 
 /**
  * Track Preview URL getter
+ * @member previewUrl
+ * @memberof Track
  */
 Object.defineProperty(Track.prototype, 'previewUrl', {
   get: function () {

--- a/lib/track.js
+++ b/lib/track.js
@@ -55,6 +55,7 @@ Object.defineProperty(Track.prototype, 'previewUrl', {
 /**
  * Loads all the metadata for this Track instance. Useful for when you get an only
  * partially filled Track instance from an Album instance for example.
+ * @function
  *
  * @param {Function} fn callback function
  * @api public

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 
 /**
  * Module dependencies.
+ * @private
  */
 
 var base62 = require('./base62');
@@ -8,6 +9,7 @@ var base62 = require('./base62');
 /**
  * Converts a GID Buffer to an ID hex string.
  * Based off of Spotify.Utils.str2hex(), modified to work with Buffers.
+ * @private
  */
 
 exports.gid2id = function (gid) {
@@ -19,6 +21,7 @@ exports.gid2id = function (gid) {
 
 /**
  * ID -> URI
+ * @private
  */
 
 exports.id2uri = function (uriType, v) {
@@ -33,6 +36,7 @@ exports.id2uri = function (uriType, v) {
  * 'd49fcea60d1f450691669b67af3bda24'
  * >>> SpotifyUtil.uri2id('spotify:user:tootallnate:playlist:0Lt5S4hGarhtZmtz7BNTeX')
  * '192803a20370c0995f271891a32da6a3'
+ * @private
  */
 
 exports.uri2id = function (uri) {
@@ -49,6 +53,7 @@ exports.uri2id = function (uri) {
 
 /**
  * GID -> URI
+ * @private
  */
 
 exports.gid2uri = function (uriType, gid) {
@@ -59,6 +64,7 @@ exports.gid2uri = function (uriType, gid) {
 /**
  * Accepts a String URI, returns the "type" of URI.
  * i.e. one of "local", "playlist", "track", etc.
+ * @private
  */
 
 exports.uriType = function (uri) {


### PR DESCRIPTION
Adds documentation to [doclets.io](https://doclets.io) service. Future tags and master branch will be published automatically. 

[Preview generated with my account](https://doclets.io/lipp/node-spotify-web/add-to-doclets)

@TooTallNate  If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :)

Steps required (3min):
1) nate logs in to doclets.io
2) nate adds node-spotify-web
3) someone merges this PR
